### PR TITLE
Improve template detail save workflow

### DIFF
--- a/paginas/movimientos/plantilla_indicador/agregar.php
+++ b/paginas/movimientos/plantilla_indicador/agregar.php
@@ -40,6 +40,8 @@
 
         <button onclick="guardarCabecera(); return false;" class="btn btn-primary btn-lg px-5">Guardar Cabecera</button>
 
+        <button onclick="guardarPlantilla(); return false;" class="btn btn-success btn-lg px-5">Guardar Plantilla</button>
+
         <button onclick="mostrarListarPlantilla(); return false;" class="btn btn-secondary btn-lg px-5">Volver</button>
       </div>
     </form>

--- a/vista/plantilla_indicador.js
+++ b/vista/plantilla_indicador.js
@@ -1,3 +1,5 @@
+let tmpIdCounter = 1;
+
 function mostrarListarPlantilla(){
     let contenido = dameContenido("paginas/movimientos/plantilla_indicador/listar.php");
     $("#contenido-principal").html(contenido);
@@ -7,6 +9,7 @@ function mostrarListarPlantilla(){
 function mostrarAgregarPlantilla(){
     let contenido = dameContenido("paginas/movimientos/plantilla_indicador/agregar.php");
     $("#contenido-principal").html(contenido);
+    tmpIdCounter = 1;
     cargarListaEspecialidad("#especialidad_id");
 }
 
@@ -45,31 +48,20 @@ async function guardarCabecera(){
     mensaje_dialogo_success(mensaje,'\u00c9xitoso');
 }
 
-function agregarFilaDetalle(data=null){
+function agregarFilaDetalle(data = null) {
     if($("#id_cabecera_edicion").val()==='0'){
         mensaje_dialogo_info_ERROR('Debe guardar la cabecera primero','Atenci\u00f3n');
         return;
     }
-
-    const text =  resp.text();
-    if(text.trim().length>0){
-        mensaje_dialogo_info(`No se pudo guardar: ${text}`,'Error');
-        return;
-    }
-    mensaje_dialogo_success(mensaje,'\u00c9xitoso');
-    mostrarListarPlantilla();
-}
-
-
-function agregarFilaDetalle(data = null) {
     let idDetalle = data?.id_plantilla_indicador_detalle ?? 0;
+    let tmp = data?.tmp_id ?? tmpIdCounter++;
     let descripcion = (data?.descripcion ?? '').replace(/"/g, '&quot;');
     let puntaje = data?.puntaje ?? 0;
     let orden = data?.orden ?? data?.nivel ?? 0;
     let idPadre = data?.id_padre ?? 0;
     let estado = data?.estado ?? 'ACTIVO';
 
-    let fila = `<tr data-id="${idDetalle}">
+    let fila = `<tr data-id="${idDetalle}" data-tmp="${tmp}">
         <td><input type="text" class="form-control desc_det" value="${descripcion}"></td>
         <td><input type="number" class="form-control puntaje_det" value="${puntaje}"></td>
         <td><input type="number" class="form-control orden_det" value="${orden}"></td>
@@ -178,6 +170,53 @@ async function guardarDetalle($tr){
         $tr.attr('data-id', id.trim());
     }
     mensaje_dialogo_success('Detalle guardado','\u00c9xitoso');
+}
+
+async function guardarPlantilla(){
+    if($("#especialidad_id").val()===null){
+        mensaje_dialogo_info_ERROR('Debe seleccionar una especialidad','Atenci\u00f3n');
+        return;
+    }
+    let cabecera = {
+        id_especialidad: $("#especialidad_id").val(),
+        estado: $("#estado_cab").val()
+    };
+    if($("#id_cabecera_edicion").val() !== '0'){
+        cabecera.id_plantilla_indicador_cabecera = $("#id_cabecera_edicion").val();
+    }
+    let detalles = [];
+    $("#detalle_tb tr").each(function(){
+        const $tr = $(this);
+        let obj = {
+            descripcion: $tr.find('.desc_det').val(),
+            puntaje: $tr.find('.puntaje_det').val(),
+            orden: $tr.find('.orden_det').val(),
+            id_padre: $tr.find('.padre_det').val(),
+            estado: $tr.find('.estado_det').val(),
+            tmp_id: $tr.data('tmp')
+        };
+        if($tr.data('id')) obj.id_detalle = $tr.data('id');
+        detalles.push(obj);
+    });
+    let payload = {cabecera, detalles};
+    let body = new URLSearchParams();
+    if($("#id_cabecera_edicion").val()==='0'){
+        body.append('guardar_completo', JSON.stringify(payload));
+    }else{
+        body.append('actualizar_completo', JSON.stringify(payload));
+    }
+    const resp = await fetch('controlador/plantilla_indicador.php',{
+        method:'POST',
+        headers:{'Content-Type':'application/x-www-form-urlencoded;charset=UTF-8'},
+        body: body
+    });
+    const text = await resp.text();
+    if(text.trim().length>0){
+        mensaje_dialogo_info(`No se pudo guardar: ${text}`,'Error');
+        return;
+    }
+    mensaje_dialogo_success('Plantilla guardada','\u00c9xitoso');
+    mostrarListarPlantilla();
 }
 
 


### PR DESCRIPTION
## Summary
- add a full save button for plantilla to store header and details together
- keep track of temporary IDs when adding details
- support saving whole template with new `guardarPlantilla` JS function

## Testing
- `node -v`
- `node -c vista/plantilla_indicador.js` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6864222732ec833395bb2fd332ffe83a