### PR TITLE
Implement Proyecto Curso CRUD

### DIFF
--- a/controlador/proyecto_curso.php
+++ b/controlador/proyecto_curso.php
@@ -1,0 +1,59 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    $json = json_decode($_POST['guardar'], true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("INSERT INTO proyecto_curso(id_curso, id_proyecto, estado) VALUES (:id_curso, :id_proyecto, :estado)");
+    $query->execute([
+        'id_curso' => $json['id_curso'],
+        'id_proyecto' => $json['id_proyecto'],
+        'estado' => $json['estado']
+    ]);
+    exit;
+}
+
+if (isset($_POST['actualizar'])) {
+    $json = json_decode($_POST['actualizar'], true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("UPDATE proyecto_curso SET id_curso=:id_curso, id_proyecto=:id_proyecto, estado=:estado WHERE id_proyecto_curso=:id");
+    $query->execute([
+        'id' => $json['id_proyecto_curso'],
+        'id_curso' => $json['id_curso'],
+        'id_proyecto' => $json['id_proyecto'],
+        'estado' => $json['estado']
+    ]);
+    exit;
+}
+
+if (isset($_POST['eliminar'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("DELETE FROM proyecto_curso WHERE id_proyecto_curso=:id");
+    $query->execute(['id' => $_POST['eliminar']]);
+    exit;
+}
+
+if (isset($_POST['leer'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT pc.id_proyecto_curso, pc.estado, pc.id_curso, pc.id_proyecto, c.descripcion AS curso, p.descripcion AS proyecto FROM proyecto_curso pc INNER JOIN cursos c ON c.id_curso=pc.id_curso INNER JOIN proyectos p ON p.id_proyecto=pc.id_proyecto ORDER BY pc.id_proyecto_curso DESC");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+    exit;
+}
+
+if (isset($_POST['leer_id'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT id_proyecto_curso, id_curso, id_proyecto, estado FROM proyecto_curso WHERE id_proyecto_curso = :id");
+    $query->execute(['id' => $_POST['leer_id']]);
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+    exit;
+}
+?>

--- a/menu-admin.php
+++ b/menu-admin.php
@@ -404,6 +404,7 @@
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarTurnos(); return false;"  href="#">Turno</a></li>
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarCurso(); return false;"  href="#">Curso</a></li>
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarProyecto(); return false;"  href="#">Proyecto</a></li>
+                                    <li class="nav-item"> <a class="nav-link" onclick="mostrarListarProyectoCurso(); return false;"  href="#">Proyecto Curso</a></li>
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarEspecialidad(); return false;"  href="#">Especialidad</a></li>
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarCursoEspecialidad(); return false;"  href="#">Curso Especialidad</a></li>
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarPlantilla(); return false;"  href="#">Plantilla Indicador</a></li>
@@ -469,6 +470,7 @@
         <script src="vista/proyecto.js"></script>
         <script src="vista/especialidad.js"></script>
         <script src="vista/curso_especialidad.js"></script>
+        <script src="vista/proyecto_curso.js"></script>
         <script src="vista/plantilla_indicador.js"></script>
         <!-- End custom js for this page-->
     </body>

--- a/menu.php
+++ b/menu.php
@@ -295,6 +295,12 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" onclick="mostrarListarProyectoCurso(); return false;" href="#">
+                                <i class="typcn typcn-th-list menu-icon"></i>
+                                <span class="menu-title">Proyecto Curso</span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" onclick="mostrarListarEspecialidad(); return false;" href="#">
                                 <i class="typcn typcn-th-small-outline menu-icon"></i>
                                 <span class="menu-title">Especialidad</span>
@@ -373,6 +379,7 @@
         <script src="vista/registro_medidas.js"></script>
         <script src="vista/curso.js"></script>
         <script src="vista/proyecto.js"></script>
+        <script src="vista/proyecto_curso.js"></script>
         <script src="vista/especialidad.js"></script>
         <script src="vista/curso_especialidad.js"></script>
         <script src="vista/plantilla_indicador.js"></script>

--- a/paginas/movimientos/proyecto_curso/agregar.php
+++ b/paginas/movimientos/proyecto_curso/agregar.php
@@ -1,0 +1,29 @@
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h5 class="card-title mb-4 text-center">Registrar Proyecto Curso</h5>
+    <input type="text" id="id_proyecto_curso_edicion" value="0" hidden>
+    <form>
+      <div class="row g-3">
+        <div class="col-md-4">
+          <label for="curso_id" class="form-label">Curso</label>
+          <select id="curso_id" class="form-control"></select>
+        </div>
+        <div class="col-md-4">
+          <label for="proyecto_id" class="form-label">Proyecto</label>
+          <select id="proyecto_id" class="form-control"></select>
+        </div>
+        <div class="col-md-4">
+          <label for="estado" class="form-label">Estado</label>
+          <select id="estado" class="form-control">
+            <option value="ACTIVO" selected>Activo</option>
+            <option value="INACTIVO">Inactivo</option>
+          </select>
+        </div>
+      </div>
+      <div class="mt-4">
+        <button onclick="guardarProyectoCurso(); return false;" class="btn btn-primary btn-lg px-5">Registrar</button>
+        <button onclick="mostrarListarProyectoCurso(); return false;" class="btn btn-secondary btn-lg px-5">Volver</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/paginas/movimientos/proyecto_curso/listar.php
+++ b/paginas/movimientos/proyecto_curso/listar.php
@@ -1,0 +1,26 @@
+<div class="container-fluid card" style="padding: 30px;">
+    <div class="row">
+        <div class="col-md-10">
+            <h3>Lista de Proyecto Curso</h3>
+        </div>
+        <div class="col-md-3">
+            <button class="form-control btn btn-primary" onclick="mostrarAgregarProyectoCurso(); return false;"><i class="fa fa-save"></i> Agregar</button>
+        </div>
+        <div class="col-md-12" style="margin-top: 30px;">
+            <div class="table-responsive">
+                <table class="table table-bordered table-striped table-head-bg-primary mt-4">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Curso</th>
+                            <th>Proyecto</th>
+                            <th>Estado</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="proyecto_curso_tb"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/vista/proyecto_curso.js
+++ b/vista/proyecto_curso.js
@@ -1,0 +1,137 @@
+function mostrarListarProyectoCurso() {
+    let contenido = dameContenido("paginas/movimientos/proyecto_curso/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaProyectoCurso();
+}
+
+function mostrarAgregarProyectoCurso() {
+    let contenido = dameContenido("paginas/movimientos/proyecto_curso/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaCursos("#curso_id");
+    cargarListaProyectos("#proyecto_id");
+}
+
+async function guardarProyectoCurso() {
+    if($("#curso_id").val()===null){
+        mensaje_dialogo_info_ERROR("Debe seleccionar un curso","ATENCION");
+        return;
+    }
+    if($("#proyecto_id").val()===null){
+        mensaje_dialogo_info_ERROR("Debe seleccionar un proyecto","ATENCION");
+        return;
+    }
+    let payload = {
+        id_curso: $("#curso_id").val(),
+        id_proyecto: $("#proyecto_id").val(),
+        estado: $("#estado").val()
+    };
+    let body_content = new URLSearchParams();
+    let mensaje = 'Registro guardado correctamente';
+    if($("#id_proyecto_curso_edicion").val() === "0"){
+        body_content.append('guardar', JSON.stringify(payload));
+    }else{
+        payload = {...payload, id_proyecto_curso: $("#id_proyecto_curso_edicion").val()};
+        body_content.append('actualizar', JSON.stringify(payload));
+        mensaje = 'Registro actualizado correctamente';
+    }
+    const response = await fetch('controlador/proyecto_curso.php', {
+        method:'POST',
+        headers:{'Content-Type':'application/x-www-form-urlencoded;charset=UTF-8'},
+        body: body_content
+    });
+    const text = await response.text();
+    if(text.trim().length > 0){
+        mensaje_dialogo_info(`No se pudo guardar: ${text}`,'Error');
+        return;
+    }
+    mensaje_dialogo_success(mensaje,'Éxitoso');
+    mostrarListarProyectoCurso();
+}
+
+async function cargarTablaProyectoCurso(){
+    let data = ejecutarAjax('controlador/proyecto_curso.php','leer=1');
+    let fila = "";
+    if(data === "0"){
+        fila = "NO HAY REGISTROS";
+    }else{
+        let json_data = JSON.parse(data);
+        json_data.map(function(item){
+            fila += `<tr>`;
+            fila += `<td>${item.id_proyecto_curso}</td>`;
+            fila += `<td>${item.curso}</td>`;
+            fila += `<td>${item.proyecto}</td>`;
+            fila += `<td>${item.estado}</td>`;
+            fila += `<td>
+                        <button class='btn btn-warning editar-proyecto-curso'><i class='fa fa-edit'></i> Editar</button>
+                        <button class='btn btn-danger eliminar-proyecto-curso'><i class='fa fa-trash'></i> Eliminar</button>
+                    </td>`;
+            fila += `</tr>`;
+        });
+    }
+    $("#proyecto_curso_tb").html(fila);
+}
+
+$(document).on("click", ".editar-proyecto-curso", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    let registro = ejecutarAjax('controlador/proyecto_curso.php', 'leer_id='+id);
+    let json_registro = JSON.parse(registro);
+    mostrarAgregarProyectoCurso();
+    $("#curso_id").val(json_registro.id_curso).trigger('change');
+    $("#proyecto_id").val(json_registro.id_proyecto).trigger('change');
+    $("#estado").val(json_registro.estado);
+    $("#id_proyecto_curso_edicion").val(json_registro.id_proyecto_curso);
+});
+
+$(document).on("click", ".eliminar-proyecto-curso", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    Swal.fire({
+        title:'Atencion',
+        text:'Desea eliminar el registro?',
+        icon:'question',
+        showCancelButton:true,
+        confirmButtonColor:'#3085d6',
+        cancelButtonColor:'#d33',
+        cancelButtonText:'No',
+        confirmButtonText:'Si'
+    }).then((result)=>{
+        if(result.isConfirmed){
+            ejecutarAjax('controlador/proyecto_curso.php','eliminar='+id);
+            mensaje_dialogo_success('Registro eliminado','Exitoso');
+            mostrarListarProyectoCurso();
+        }
+    });
+});
+
+async function cargarListaCursos(selector){
+    const $sel = $(selector).empty().append($('<option>',{value:'',text:'Selecciona un curso',disabled:true,selected:true}));
+    try{
+        const resp = await fetch('controlador/curso.php',{
+            method:'POST',
+            headers:{'Content-Type':'application/x-www-form-urlencoded;charset=UTF-8'},
+            body:new URLSearchParams({leer:'1'})
+        });
+        if(!resp.ok) throw new Error(resp.status);
+        const datos = await resp.json();
+        datos.forEach(({id_curso, descripcion})=>{
+            $sel.append($('<option>',{value:id_curso,text:descripcion}));
+        });
+        $sel.select2 && $sel.select2({width:'100%',allowClear:true});
+    }catch(e){console.error(e);}
+}
+
+async function cargarListaProyectos(selector){
+    const $sel = $(selector).empty().append($('<option>',{value:'',text:'Selecciona un proyecto',disabled:true,selected:true}));
+    try{
+        const resp = await fetch('controlador/proyecto.php',{
+            method:'POST',
+            headers:{'Content-Type':'application/x-www-form-urlencoded;charset=UTF-8'},
+            body:new URLSearchParams({leer:'1'})
+        });
+        if(!resp.ok) throw new Error(resp.status);
+        const datos = await resp.json();
+        datos.forEach(({id_proyecto, descripcion})=>{
+            $sel.append($('<option>',{value:id_proyecto,text:descripcion}));
+        });
+        $sel.select2 && $sel.select2({width:'100%',allowClear:true});
+    }catch(e){console.error(e);}
+}


### PR DESCRIPTION
## Summary
- add backend controller for `proyecto_curso`
- provide JS helpers and UI pages for CRUD operations
- hook Proyecto Curso in admin and standard menus
- load new JS script in menus

## Testing
- `php -l controlador/proyecto_curso.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864849450e883339de42b33be8d306d