### PR TITLE
Implement indicador CRUD

### DIFF
--- a/controlador/indicador.php
+++ b/controlador/indicador.php
@@ -1,0 +1,96 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    $json = json_decode($_POST['guardar'], true);
+    $db = new DB();
+    $c = $db->conectar();
+    $c->beginTransaction();
+    try {
+        $stmt = $c->prepare("INSERT INTO indicador_cabecera(id_proyecto_curso,titulo,id_plantilla,nro_stand,estado) VALUES(:proyecto,:titulo,:plantilla,:stand,:estado)");
+        $stmt->execute([
+            'proyecto' => $json['id_proyecto_curso'],
+            'titulo' => $json['titulo'],
+            'plantilla' => $json['id_plantilla'],
+            'stand' => $json['nro_stand'],
+            'estado' => $json['estado']
+        ]);
+        $cabId = $c->lastInsertId();
+
+        $q = $c->prepare("SELECT id_plantilla_indicador_detalle,id_padre,nivel,descripcion,puntaje FROM plantilla_indicador_detalle WHERE id_plantilla_indicador_cabecera=:id ORDER BY id_plantilla_indicador_detalle");
+        $q->execute(['id' => $json['id_plantilla']]);
+        $ins = $c->prepare("INSERT INTO indicador_detalle(id_indicador_cabecera,id_padre,nivel,descripcion,puntaje,logrado) VALUES(:cab,:padre,:nivel,:desc,:puntaje,:logrado)");
+        $map = [];
+        while ($row = $q->fetch(PDO::FETCH_ASSOC)) {
+            $padre = 0;
+            if ((int)$row['id_padre'] !== 0) {
+                $padre = $map[$row['id_padre']] ?? (int)$row['id_padre'];
+            }
+            $ins->execute([
+                'cab' => $cabId,
+                'padre' => $padre,
+                'nivel' => $row['nivel'],
+                'desc' => $row['descripcion'],
+                'puntaje' => $row['puntaje'],
+                'logrado' => 0
+            ]);
+            $newId = $c->lastInsertId();
+            $map[$row['id_plantilla_indicador_detalle']] = $newId;
+        }
+        $c->commit();
+        echo $cabId;
+    } catch (Exception $e) {
+        $c->rollBack();
+        echo $e->getMessage();
+    }
+    exit;
+}
+
+if (isset($_POST['actualizar'])) {
+    $json = json_decode($_POST['actualizar'], true);
+    $db = new DB();
+    $c = $db->conectar();
+    $stmt = $c->prepare("UPDATE indicador_cabecera SET id_proyecto_curso=:proyecto,titulo=:titulo,id_plantilla=:plantilla,nro_stand=:stand,estado=:estado WHERE id_indicador_cabecera=:id");
+    $stmt->execute([
+        'id' => $json['id_indicador_cabecera'],
+        'proyecto' => $json['id_proyecto_curso'],
+        'titulo' => $json['titulo'],
+        'plantilla' => $json['id_plantilla'],
+        'stand' => $json['nro_stand'],
+        'estado' => $json['estado']
+    ]);
+    exit;
+}
+
+if (isset($_POST['eliminar'])) {
+    $db = new DB();
+    $c = $db->conectar();
+    $c->prepare("DELETE FROM indicador_detalle WHERE id_indicador_cabecera=:id")->execute(['id' => $_POST['eliminar']]);
+    $c->prepare("DELETE FROM indicador_cabecera WHERE id_indicador_cabecera=:id")->execute(['id' => $_POST['eliminar']]);
+    exit;
+}
+
+if (isset($_POST['leer'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT ic.id_indicador_cabecera, ic.titulo, ic.nro_stand, ic.estado, c.descripcion AS curso, p.descripcion AS proyecto FROM indicador_cabecera ic INNER JOIN proyecto_curso pc ON pc.id_proyecto_curso=ic.id_proyecto_curso INNER JOIN cursos c ON c.id_curso=pc.id_curso INNER JOIN proyectos p ON p.id_proyecto=pc.id_proyecto ORDER BY ic.id_indicador_cabecera DESC");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+    exit;
+}
+
+if (isset($_POST['leer_id'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT id_indicador_cabecera,id_proyecto_curso,titulo,id_plantilla,nro_stand,estado FROM indicador_cabecera WHERE id_indicador_cabecera=:id");
+    $query->execute(['id' => $_POST['leer_id']]);
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+    exit;
+}
+?>

--- a/menu-admin.php
+++ b/menu-admin.php
@@ -408,6 +408,7 @@
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarEspecialidad(); return false;"  href="#">Especialidad</a></li>
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarCursoEspecialidad(); return false;"  href="#">Curso Especialidad</a></li>
                                     <li class="nav-item"> <a class="nav-link" onclick="mostrarListarPlantilla(); return false;"  href="#">Plantilla Indicador</a></li>
+                                    <li class="nav-item"> <a class="nav-link" onclick="mostrarListarIndicador(); return false;"  href="#">Indicador</a></li>
 
                                 </ul>
                             </div>
@@ -472,6 +473,7 @@
         <script src="vista/curso_especialidad.js"></script>
         <script src="vista/proyecto_curso.js"></script>
         <script src="vista/plantilla_indicador.js"></script>
+        <script src="vista/indicador.js"></script>
         <!-- End custom js for this page-->
     </body>
     <script>

--- a/menu.php
+++ b/menu.php
@@ -319,6 +319,12 @@
                                 <span class="menu-title">Plantilla Indicador</span>
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" onclick="mostrarListarIndicador(); return false;" href="#">
+                                <i class="typcn typcn-document-text menu-icon"></i>
+                                <span class="menu-title">Indicador</span>
+                            </a>
+                        </li>
 
                         <li class="nav-item">
                             <a class="nav-link" href="controlador/cerrarSesion.php" aria-expanded="false" >
@@ -383,6 +389,7 @@
         <script src="vista/especialidad.js"></script>
         <script src="vista/curso_especialidad.js"></script>
         <script src="vista/plantilla_indicador.js"></script>
+        <script src="vista/indicador.js"></script>
 
 
 

--- a/paginas/movimientos/indicador/agregar.php
+++ b/paginas/movimientos/indicador/agregar.php
@@ -1,0 +1,37 @@
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h5 class="card-title mb-4 text-center">Registrar Indicador</h5>
+    <input type="text" id="id_indicador_edicion" value="0" hidden>
+    <form>
+      <div class="row g-3">
+        <div class="col-md-4">
+          <label for="proyecto_curso_id" class="form-label">Proyecto Curso</label>
+          <select id="proyecto_curso_id" class="form-control"></select>
+        </div>
+        <div class="col-md-4">
+          <label for="plantilla_id" class="form-label">Plantilla</label>
+          <select id="plantilla_id" class="form-control"></select>
+        </div>
+        <div class="col-md-4">
+          <label for="nro_stand" class="form-label">Nro Stand</label>
+          <input type="text" id="nro_stand" class="form-control">
+        </div>
+        <div class="col-md-8">
+          <label for="titulo" class="form-label">Titulo</label>
+          <input type="text" id="titulo" class="form-control">
+        </div>
+        <div class="col-md-4">
+          <label for="estado_ind" class="form-label">Estado</label>
+          <select id="estado_ind" class="form-control">
+            <option value="ACTIVO" selected>Activo</option>
+            <option value="INACTIVO">Inactivo</option>
+          </select>
+        </div>
+      </div>
+      <div class="mt-4">
+        <button onclick="guardarIndicador(); return false;" class="btn btn-primary btn-lg px-5">Guardar</button>
+        <button onclick="mostrarListarIndicador(); return false;" class="btn btn-secondary btn-lg px-5">Volver</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/paginas/movimientos/indicador/listar.php
+++ b/paginas/movimientos/indicador/listar.php
@@ -1,0 +1,28 @@
+<div class="container-fluid card" style="padding: 30px;">
+    <div class="row">
+        <div class="col-md-10">
+            <h3>Lista de Indicadores</h3>
+        </div>
+        <div class="col-md-3">
+            <button class="form-control btn btn-primary" onclick="mostrarAgregarIndicador(); return false;"><i class="fa fa-save"></i> Agregar</button>
+        </div>
+        <div class="col-md-12" style="margin-top: 30px;">
+            <div class="table-responsive">
+                <table class="table table-bordered table-striped table-head-bg-primary mt-4">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Titulo</th>
+                            <th>Curso</th>
+                            <th>Proyecto</th>
+                            <th>Stand</th>
+                            <th>Estado</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="indicador_tb"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/print_indicador.php
+++ b/print_indicador.php
@@ -1,0 +1,54 @@
+<?php
+include_once './conexion/db.php';
+
+$base_datos = new DB();
+$c = $base_datos->conectar();
+
+$query = $c->prepare("SELECT ic.titulo, ic.nro_stand, ic.estado, c.descripcion AS curso, p.descripcion AS proyecto FROM indicador_cabecera ic INNER JOIN proyecto_curso pc ON pc.id_proyecto_curso=ic.id_proyecto_curso INNER JOIN cursos c ON c.id_curso=pc.id_curso INNER JOIN proyectos p ON p.id_proyecto=pc.id_proyecto WHERE ic.id_indicador_cabecera=:id");
+$query->execute(['id' => $_GET['id']]);
+$indicador = $query->fetch(PDO::FETCH_OBJ);
+
+$qdet = $c->prepare("SELECT descripcion, puntaje, logrado FROM indicador_detalle WHERE id_indicador_cabecera=:id ORDER BY id_indicador_detalle");
+$qdet->execute(['id' => $_GET['id']]);
+$detalles = $qdet->fetchAll(PDO::FETCH_OBJ);
+?>
+<!doctype html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Impresion</title>
+    <link rel="stylesheet" href="plugins/bootstrap-5.3.3-dist/css/bootstrap.min.css">
+</head>
+<body>
+    <h3>Indicador #<?= $_GET['id'] ?></h3>
+    <table class="table table-bordered">
+        <tbody>
+            <tr><th>Titulo</th><td><?= $indicador->titulo ?></td></tr>
+            <tr><th>Curso</th><td><?= $indicador->curso ?></td></tr>
+            <tr><th>Proyecto</th><td><?= $indicador->proyecto ?></td></tr>
+            <tr><th>Nro Stand</th><td><?= $indicador->nro_stand ?></td></tr>
+            <tr><th>Estado</th><td><?= $indicador->estado ?></td></tr>
+        </tbody>
+    </table>
+    <h4>Detalles</h4>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Descripcion</th>
+                <th>Puntaje</th>
+                <th>Logrado</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach($detalles as $d): ?>
+            <tr>
+                <td><?= $d->descripcion ?></td>
+                <td><?= $d->puntaje ?></td>
+                <td><?= $d->logrado ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</body>
+<script>window.print();</script>
+</html>

--- a/vista/indicador.js
+++ b/vista/indicador.js
@@ -1,0 +1,127 @@
+function mostrarListarIndicador(){
+    let contenido = dameContenido("paginas/movimientos/indicador/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaIndicador();
+}
+
+function mostrarAgregarIndicador(){
+    let contenido = dameContenido("paginas/movimientos/indicador/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaProyectoCurso("#proyecto_curso_id");
+    cargarListaPlantillas("#plantilla_id");
+}
+
+async function guardarIndicador(){
+    if($("#proyecto_curso_id").val()===null){
+        mensaje_dialogo_info_ERROR('Debe seleccionar un proyecto curso','Atencion');
+        return;
+    }
+    if($("#plantilla_id").val()===null){
+        mensaje_dialogo_info_ERROR('Debe seleccionar una plantilla','Atencion');
+        return;
+    }
+    let payload = {
+        id_proyecto_curso: $("#proyecto_curso_id").val(),
+        id_plantilla: $("#plantilla_id").val(),
+        nro_stand: $("#nro_stand").val(),
+        titulo: $("#titulo").val(),
+        estado: $("#estado_ind").val()
+    };
+    let body = new URLSearchParams();
+    let mensaje = 'Registro guardado correctamente';
+    if($("#id_indicador_edicion").val()==='0'){
+        body.append('guardar', JSON.stringify(payload));
+    }else{
+        payload.id_indicador_cabecera = $("#id_indicador_edicion").val();
+        body.append('actualizar', JSON.stringify(payload));
+        mensaje = 'Registro actualizado correctamente';
+    }
+    const resp = await fetch('controlador/indicador.php',{
+        method:'POST',
+        headers:{'Content-Type':'application/x-www-form-urlencoded;charset=UTF-8'},
+        body: body
+    });
+    const text = await resp.text();
+    if(text.trim().length>0){
+        mensaje_dialogo_info(`No se pudo guardar: ${text}`,'Error');
+        return;
+    }
+    mensaje_dialogo_success(mensaje,'Exitoso');
+    mostrarListarIndicador();
+}
+
+async function cargarTablaIndicador(){
+    let data = ejecutarAjax('controlador/indicador.php','leer=1');
+    let fila = '';
+    if(data !== '0'){
+        let json = JSON.parse(data);
+        json.map(function(item){
+            fila += `<tr>`;
+            fila += `<td>${item.id_indicador_cabecera}</td>`;
+            fila += `<td>${item.titulo}</td>`;
+            fila += `<td>${item.curso}</td>`;
+            fila += `<td>${item.proyecto}</td>`;
+            fila += `<td>${item.nro_stand}</td>`;
+            fila += `<td>${item.estado}</td>`;
+            fila += `<td>`+
+                    `<button class='btn btn-warning editar-indicador'><i class='fa fa-edit'></i> Editar</button> `+
+                    `<a class='btn btn-info imprimir-indicador' target='_blank' href='print_indicador.php?id=${item.id_indicador_cabecera}'><i class='fa fa-print'></i></a> `+
+                    `<button class='btn btn-danger eliminar-indicador'><i class='fa fa-trash'></i> Eliminar</button>`+
+                    `</td>`;
+            fila += `</tr>`;
+        });
+    }else{
+        fila = 'NO HAY REGISTROS';
+    }
+    $("#indicador_tb").html(fila);
+}
+
+$(document).on('click','.editar-indicador', function(){
+    let id = $(this).closest('tr').find('td:eq(0)').text();
+    let registro = ejecutarAjax('controlador/indicador.php','leer_id='+id);
+    let cab = JSON.parse(registro);
+    mostrarAgregarIndicador();
+    $("#proyecto_curso_id").val(cab.id_proyecto_curso).trigger('change');
+    $("#plantilla_id").val(cab.id_plantilla).trigger('change');
+    $("#nro_stand").val(cab.nro_stand);
+    $("#titulo").val(cab.titulo);
+    $("#estado_ind").val(cab.estado);
+    $("#id_indicador_edicion").val(cab.id_indicador_cabecera);
+});
+
+$(document).on('click','.eliminar-indicador', function(){
+    let id = $(this).closest('tr').find('td:eq(0)').text();
+    Swal.fire({title:'Atencion', text:'Desea eliminar el registro?', icon:'question', showCancelButton:true, confirmButtonText:'Si', cancelButtonText:'No'}).then(result=>{
+        if(result.isConfirmed){
+            ejecutarAjax('controlador/indicador.php','eliminar='+id);
+            mensaje_dialogo_success('Registro eliminado','Exitoso');
+            cargarTablaIndicador();
+        }
+    });
+});
+
+async function cargarListaProyectoCurso(selector){
+    const $sel = $(selector).empty().append($('<option>',{value:'',text:'Selecciona un proyecto curso',disabled:true,selected:true}));
+    try{
+        const resp = await fetch('controlador/proyecto_curso.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded;charset=UTF-8'},body:new URLSearchParams({leer:'1'})});
+        if(!resp.ok) throw new Error(resp.status);
+        const datos = await resp.json();
+        datos.forEach(({id_proyecto_curso, curso, proyecto})=>{
+            $sel.append($('<option>',{value:id_proyecto_curso,text:`${curso} - ${proyecto}`}));
+        });
+        $sel.select2 && $sel.select2({width:'100%',allowClear:true});
+    }catch(e){console.error(e);}
+}
+
+async function cargarListaPlantillas(selector){
+    const $sel = $(selector).empty().append($('<option>',{value:'',text:'Selecciona una plantilla',disabled:true,selected:true}));
+    try{
+        const resp = await fetch('controlador/plantilla_indicador.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded;charset=UTF-8'},body:new URLSearchParams({leer_cabeceras:'1'})});
+        if(!resp.ok) throw new Error(resp.status);
+        const datos = await resp.json();
+        datos.forEach(({id_plantilla_indicador_cabecera})=>{
+            $sel.append($('<option>',{value:id_plantilla_indicador_cabecera,text:`Plantilla ${id_plantilla_indicador_cabecera}`}));
+        });
+        $sel.select2 && $sel.select2({width:'100%',allowClear:true});
+    }catch(e){console.error(e);}
+}


### PR DESCRIPTION
## Summary
- add Indicador CRUD endpoints
- create forms and list pages for Indicador
- add JS logic for Indicador operations
- enable printing for Indicador records
- wire new module into navigation menus

## Testing
- `php -l controlador/indicador.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68648798a04083339c85c04dc2c3a70a