### PR TITLE
Add jurado login with specialties view

### DIFF
--- a/controlador/JuradoSession.php
+++ b/controlador/JuradoSession.php
@@ -1,0 +1,35 @@
+<?php
+require_once "../conexion/db.php";
+
+class JuradoSession {
+    public function __construct() {
+        session_start();
+    }
+
+    public function existeJurado($cedula, $pass) {
+        $passMD5 = md5($pass);
+        $db = new DB();
+        $query = $db->conectar()->prepare("SELECT id_jurado, nombre_apellido, cedula, pass, estado FROM jurados WHERE cedula = :cedula AND pass = :pass LIMIT 1");
+        $query->execute(['cedula' => $cedula, 'pass' => $passMD5]);
+        if ($query->rowCount() > 0) {
+            $jurado = $query->fetch(PDO::FETCH_ASSOC);
+            if (strtoupper($jurado['estado']) === 'ACTIVO') {
+                $_SESSION['id_jurado'] = $jurado['id_jurado'];
+                $_SESSION['nombre_completo'] = $jurado['nombre_apellido'];
+                $_SESSION['cedula'] = $jurado['cedula'];
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function juradoLogeado() {
+        return isset($_SESSION['id_jurado']);
+    }
+
+    public function cerrarSesion() {
+        session_unset();
+        session_destroy();
+    }
+}
+?>

--- a/controlador/curso_especialidad.php
+++ b/controlador/curso_especialidad.php
@@ -56,4 +56,22 @@ if (isset($_POST['leer_id'])) {
     }
     exit;
 }
+if (isset($_POST['cursos_por_especialidad'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "SELECT c.id_curso, c.descripcion
+         FROM curso_especialidades ce
+         INNER JOIN cursos c ON c.id_curso = ce.id_curso
+         WHERE ce.id_especialidad = :id
+           AND ce.estado='ACTIVO'
+           AND c.estado='ACTIVO'"
+    );
+    $query->execute(['id' => $_POST['cursos_por_especialidad']]);
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+    exit;
+}
 ?>

--- a/login_jurado.php
+++ b/login_jurado.php
@@ -1,0 +1,74 @@
+<?php
+include_once './controlador/JuradoSession.php';
+$jurado = new JuradoSession();
+$error_sesion = "";
+
+if (isset($_POST['cedula']) && isset($_POST['pass'])) {
+    $cedula = $_POST['cedula'];
+    $pass = $_POST['pass'];
+
+    if ($jurado->existeJurado($cedula, $pass)) {
+        header("Location: menu_jurado.php");
+        exit;
+    } else {
+        $error_sesion = "Credenciales inválidas";
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Login Jurado</title>
+    <link rel="stylesheet" href="vendors/typicons/typicons.css">
+    <link rel="stylesheet" href="vendors/css/vendor.bundle.base.css">
+    <link rel="stylesheet" href="css/vertical-layout-light/style.css">
+    <link rel="stylesheet" href="plugins/sweetalert/sweetalert2.min.css">
+    <script src="plugins/sweetalert/sweetalert2.min.js"></script>
+    <link rel="shortcut icon" href="images/logo-nido.png" />
+</head>
+<body>
+<div class="container-scroller">
+    <div class="container-fluid page-body-wrapper full-page-wrapper">
+        <div class="content-wrapper d-flex align-items-center auth px-0">
+            <div class="row w-100 mx-0">
+                <div class="col-lg-4 mx-auto">
+                    <div class="auth-form-light text-left py-5 px-4 px-sm-5">
+                        <div class="brand-logo text-center">
+                            <img src="images/logo-nido.png" style="width: 200px;" alt="logo">
+                        </div>
+                        <h4 class="text-center">Ingreso de Jurado</h4>
+                        <?php if (!empty($error_sesion)) : ?>
+                            <script>
+                                Swal.fire({
+                                    title: 'Atención',
+                                    text: '<?= $error_sesion ?>',
+                                    icon: 'warning'
+                                });
+                            </script>
+                        <?php endif; ?>
+                        <form class="pt-3" method="POST">
+                            <div class="form-group">
+                                <input type="text" name="cedula" class="form-control form-control-lg" placeholder="Cédula" required>
+                            </div>
+                            <div class="form-group">
+                                <input type="password" name="pass" class="form-control form-control-lg" placeholder="Contraseña" required>
+                            </div>
+                            <div class="mt-3">
+                                <button type="submit" class="btn btn-block btn-primary btn-lg font-weight-medium">Ingresar</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="plugins/sweetalert/sweetalert2.min.js"></script>
+<script src="vendors/js/vendor.bundle.base.js"></script>
+<script src="js/off-canvas.js"></script>
+<script src="js/template.js"></script>
+</body>
+</html>

--- a/menu_jurado.php
+++ b/menu_jurado.php
@@ -1,0 +1,93 @@
+<?php
+include_once './controlador/JuradoSession.php';
+$session = new JuradoSession();
+if (!$session->juradoLogeado()) {
+    header('Location: login_jurado.php');
+    exit;
+}
+include_once './conexion/db.php';
+$db = new DB();
+$stmt = $db->conectar()->prepare("SELECT id_especialidad, descripcion FROM especialidades WHERE estado='ACTIVO' ORDER BY descripcion");
+$stmt->execute();
+$especialidades = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$iconos = [
+    1 => 'typcn-book',
+    2 => 'typcn-leaf',
+    3 => 'typcn-heart',
+    4 => 'typcn-device-desktop',
+    5 => 'typcn-lightbulb',
+    6 => 'typcn-briefcase',
+    7 => 'typcn-cog',
+    8 => 'typcn-code-outline',
+    9 => 'typcn-folder',
+    10 => 'typcn-social-foursquare'
+];
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Especialidades</title>
+    <link rel="stylesheet" href="vendors/typicons/typicons.css">
+    <link rel="stylesheet" href="vendors/css/vendor.bundle.base.css">
+    <link rel="stylesheet" href="css/vertical-layout-light/style.css">
+    <link rel="stylesheet" href="plugins/sweetalert/sweetalert2.min.css">
+    <script src="plugins/sweetalert/sweetalert2.min.js"></script>
+    <link rel="shortcut icon" href="images/logo-nido.png" />
+</head>
+<body>
+<div class="container-scroller">
+    <div class="content-wrapper p-4">
+        <h3 class="mb-4">Seleccione una especialidad</h3>
+        <div class="row">
+            <?php foreach ($especialidades as $esp): $icon = $iconos[$esp['id_especialidad']] ?? 'typcn-star'; ?>
+            <div class="col-md-4 mb-3">
+                <div class="card specialty-card" data-id="<?= $esp['id_especialidad']; ?>">
+                    <div class="card-body text-center">
+                        <i class="typcn <?= $icon ?>" style="font-size:48px;"></i>
+                        <h5 class="card-title mt-2"><?= $esp['descripcion']; ?></h5>
+                    </div>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
+        <h4 class="mt-4">Cursos vinculados</h4>
+        <ul id="lista-cursos" class="list-group"></ul>
+    </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="vendors/js/vendor.bundle.base.js"></script>
+<script src="js/off-canvas.js"></script>
+<script src="js/template.js"></script>
+<script>
+$(document).on('click', '.specialty-card', function () {
+    var id = $(this).data('id');
+    $.ajax({
+        method: 'POST',
+        url: 'controlador/curso_especialidad.php',
+        data: {cursos_por_especialidad: id},
+        success: function (data) {
+            var list = $('#lista-cursos').empty();
+            data = $.trim(data);
+            if (data === '0') {
+                list.append('<li class="list-group-item">No hay cursos</li>');
+            } else {
+                try {
+                    var cursos = JSON.parse(data);
+                    cursos.forEach(function (c) {
+                        list.append('<li class="list-group-item">' + c.descripcion + '</li>');
+                    });
+                } catch (e) {
+                    list.append('<li class="list-group-item">Error al cargar cursos</li>');
+                }
+            }
+        },
+        error: function () {
+            $('#lista-cursos').html('<li class="list-group-item">Error de conexión</li>');
+        }
+    });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `JuradoSession` helper for jurado authentication
- create `login_jurado.php` for jurados
- add new `menu_jurado.php` that lists specialties as cards and loads courses
- extend `curso_especialidad` controller with `cursos_por_especialidad` endpoint
- filter active courses and add robust JS to load courses on click

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68649503c0108333879b55c021a049dc