### PR TITLE
Add jurado project grading

### DIFF
--- a/controlador/indicador.php
+++ b/controlador/indicador.php
@@ -7,9 +7,10 @@ if (isset($_POST['guardar'])) {
     $c = $db->conectar();
     $c->beginTransaction();
     try {
-        $stmt = $c->prepare("INSERT INTO indicador_cabecera(id_proyecto_curso,titulo,id_plantilla,nro_stand,estado) VALUES(:proyecto,:titulo,:plantilla,:stand,:estado)");
+        $stmt = $c->prepare("INSERT INTO indicador_cabecera(id_proyecto_curso,id_jurado,titulo,id_plantilla,nro_stand,estado) VALUES(:proyecto,:jurado,:titulo,:plantilla,:stand,:estado)");
         $stmt->execute([
             'proyecto' => $json['id_proyecto_curso'],
+            'jurado' => $json['id_jurado'],
             'titulo' => $json['titulo'],
             'plantilla' => $json['id_plantilla'],
             'stand' => $json['nro_stand'],
@@ -50,10 +51,11 @@ if (isset($_POST['actualizar'])) {
     $json = json_decode($_POST['actualizar'], true);
     $db = new DB();
     $c = $db->conectar();
-    $stmt = $c->prepare("UPDATE indicador_cabecera SET id_proyecto_curso=:proyecto,titulo=:titulo,id_plantilla=:plantilla,nro_stand=:stand,estado=:estado WHERE id_indicador_cabecera=:id");
+    $stmt = $c->prepare("UPDATE indicador_cabecera SET id_proyecto_curso=:proyecto,id_jurado=:jurado,titulo=:titulo,id_plantilla=:plantilla,nro_stand=:stand,estado=:estado WHERE id_indicador_cabecera=:id");
     $stmt->execute([
         'id' => $json['id_indicador_cabecera'],
         'proyecto' => $json['id_proyecto_curso'],
+        'jurado' => $json['id_jurado'],
         'titulo' => $json['titulo'],
         'plantilla' => $json['id_plantilla'],
         'stand' => $json['nro_stand'],
@@ -121,6 +123,69 @@ if (isset($_POST['calificar'])) {
     } catch (Exception $e) {
         $c->rollBack();
         echo $e->getMessage();
+    }
+    exit;
+}
+
+if (isset($_POST['existe_jurado_proyecto'])) {
+    $db = new DB();
+    $c = $db->conectar();
+    $stmt = $c->prepare("SELECT id_indicador_cabecera FROM indicador_cabecera WHERE id_proyecto_curso=:pc AND id_jurado=:j LIMIT 1");
+    $stmt->execute(['pc' => $_POST['id_proyecto_curso'], 'j' => $_POST['id_jurado']]);
+    if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        echo $row['id_indicador_cabecera'];
+    } else {
+        echo '0';
+    }
+    exit;
+}
+
+if (isset($_POST['crear_para_jurado'])) {
+    $db = new DB();
+    $c = $db->conectar();
+    $c->beginTransaction();
+    try {
+        $stmt = $c->prepare("SELECT ce.id_especialidad FROM proyecto_curso pc JOIN curso_especialidades ce ON ce.id_curso=pc.id_curso WHERE pc.id_proyecto_curso=:id LIMIT 1");
+        $stmt->execute(['id' => $_POST['id_proyecto_curso']]);
+        $esp = $stmt->fetchColumn();
+        if (!$esp) {
+            echo '0';
+            exit;
+        }
+        $stmt = $c->prepare("SELECT id_plantilla_indicador_cabecera FROM plantilla_indicadores_cabecera WHERE id_especialidad=:esp AND estado='ACTIVO' ORDER BY id_plantilla_indicador_cabecera DESC LIMIT 1");
+        $stmt->execute(['esp' => $esp]);
+        $plantilla = $stmt->fetchColumn();
+        if (!$plantilla) {
+            echo '0';
+            exit;
+        }
+        $insCab = $c->prepare("INSERT INTO indicador_cabecera(id_proyecto_curso,id_jurado,titulo,id_plantilla,nro_stand,estado) VALUES(:pc,:j,'',:plantilla,'','ACTIVO')");
+        $insCab->execute(['pc' => $_POST['id_proyecto_curso'], 'j' => $_POST['id_jurado'], 'plantilla' => $plantilla]);
+        $cabId = $c->lastInsertId();
+
+        $q = $c->prepare("SELECT id_plantilla_indicador_detalle,id_padre,nivel,descripcion,puntaje FROM plantilla_indicador_detalle WHERE id_plantilla_indicador_cabecera=:id ORDER BY id_plantilla_indicador_detalle");
+        $q->execute(['id' => $plantilla]);
+        $ins = $c->prepare("INSERT INTO indicador_detalle(id_indicador_cabecera,id_padre,nivel,descripcion,puntaje,logrado) VALUES(:cab,:padre,:nivel,:desc,:puntaje,0)");
+        $map = [];
+        while ($row = $q->fetch(PDO::FETCH_ASSOC)) {
+            $padre = 0;
+            if ((int)$row['id_padre'] !== 0) {
+                $padre = $map[$row['id_padre']] ?? (int)$row['id_padre'];
+            }
+            $ins->execute([
+                'cab' => $cabId,
+                'padre' => $padre,
+                'nivel' => $row['nivel'],
+                'desc' => $row['descripcion'],
+                'puntaje' => $row['puntaje']
+            ]);
+            $map[$row['id_plantilla_indicador_detalle']] = $c->lastInsertId();
+        }
+        $c->commit();
+        echo $cabId;
+    } catch (Exception $e) {
+        $c->rollBack();
+        echo '0';
     }
     exit;
 }

--- a/controlador/proyecto_curso.php
+++ b/controlador/proyecto_curso.php
@@ -60,7 +60,7 @@ if (isset($_POST['leer_id'])) {
 if (isset($_POST['proyectos_por_curso'])) {
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT p.id_proyecto, p.descripcion
+        "SELECT pc.id_proyecto_curso, p.id_proyecto, p.descripcion
          FROM proyecto_curso pc
          INNER JOIN proyectos p ON p.id_proyecto = pc.id_proyecto
          WHERE pc.id_curso = :id

--- a/cpcc.sql
+++ b/cpcc.sql
@@ -99,6 +99,7 @@ INSERT INTO `especialidades` (`id_especialidad`, `descripcion`, `estado`) VALUES
 CREATE TABLE `indicador_cabecera` (
   `id_indicador_cabecera` int(11) NOT NULL,
   `id_proyecto_curso` int(11) NOT NULL,
+  `id_jurado` int(11) NOT NULL,
   `titulo` varchar(200) NOT NULL,
   `id_plantilla` int(11) NOT NULL,
   `nro_stand` varchar(20) NOT NULL,
@@ -109,8 +110,8 @@ CREATE TABLE `indicador_cabecera` (
 -- Volcado de datos para la tabla `indicador_cabecera`
 --
 
-INSERT INTO `indicador_cabecera` (`id_indicador_cabecera`, `id_proyecto_curso`, `titulo`, `id_plantilla`, `nro_stand`, `estado`) VALUES
-(8, 2, 'NUEVO', 1, '222', 'ACTIVO');
+INSERT INTO `indicador_cabecera` (`id_indicador_cabecera`, `id_proyecto_curso`, `id_jurado`, `titulo`, `id_plantilla`, `nro_stand`, `estado`) VALUES
+(8, 2, 1, 'NUEVO', 1, '222', 'ACTIVO');
 
 -- --------------------------------------------------------
 
@@ -674,7 +675,8 @@ ALTER TABLE `especialidades`
 -- Indices de la tabla `indicador_cabecera`
 --
 ALTER TABLE `indicador_cabecera`
-  ADD PRIMARY KEY (`id_indicador_cabecera`);
+  ADD PRIMARY KEY (`id_indicador_cabecera`),
+  ADD KEY `id_jurado` (`id_jurado`);
 
 --
 -- Indices de la tabla `indicador_detalle`

--- a/menu_jurado.php
+++ b/menu_jurado.php
@@ -69,6 +69,7 @@ $iconos = [
 <script src="js/off-canvas.js"></script>
 <script src="js/template.js"></script>
 <script>
+var JURADO_ID = <?= $_SESSION['id_jurado']; ?>;
 
 var historyStack = [];
 
@@ -112,7 +113,7 @@ function renderProjects(projects){
     html += '<h3 class="mb-4">Proyectos</h3><div class="row">';
     projects.forEach(function(p){
         html += '<div class="col-md-4 mb-3">';
-        html += '  <div class="card project-card">';
+        html += '  <div class="card project-card" data-id="'+p.id_proyecto_curso+'">';
         html += '    <div class="card-body text-center">';
         html += '      <i class="typcn typcn-folder" style="font-size:48px;"></i>';
         html += '      <h5 class="card-title mt-2">'+p.descripcion+'</h5>';
@@ -158,6 +159,47 @@ $(document).on('click','.course-card',function(){
 
 
 
+    });
+});
+
+$(document).on('click','.project-card',function(){
+    var id = $(this).data('id');
+    $.ajax({
+        method:'POST',
+        url:'controlador/indicador.php',
+        data:{existe_jurado_proyecto:1,id_proyecto_curso:id,id_jurado:JURADO_ID},
+        success:function(data){
+            data = $.trim(data);
+            if(data === '0'){
+                Swal.fire({
+                    title:'¿Desea calificar el proyecto?',
+                    icon:'question',
+                    showCancelButton:true,
+                    confirmButtonText:'Si',
+                    cancelButtonText:'No'
+                }).then(function(res){
+                    if(res.isConfirmed){
+                        $.ajax({
+                            method:'POST',
+                            url:'controlador/indicador.php',
+                            data:{crear_para_jurado:1,id_proyecto_curso:id,id_jurado:JURADO_ID},
+                            success:function(resp){
+                                resp = $.trim(resp);
+                                if(resp !== '0'){
+                                    window.location.href='print_indicador.php?id='+resp;
+                                }else{
+                                    renderMessage('No se pudo crear evaluación');
+                                }
+                            },
+                            error:function(){ renderMessage('Error de conexión'); }
+                        });
+                    }
+                });
+            }else{
+                window.location.href='print_indicador.php?id='+data;
+            }
+        },
+        error:function(){ renderMessage('Error de conexión'); }
     });
 });
 


### PR DESCRIPTION
## Summary
- extend `indicador_cabecera` table with `id_jurado`
- expose project-course id in project listing
- let jurado start grading projects from menu
- allow backend to create and lookup grading records

## Testing
- `php -l menu_jurado.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649f579d5883338c70fde1248064c6