### PR TITLE
Add aggregated results page

### DIFF
--- a/controlador/resultados.php
+++ b/controlador/resultados.php
@@ -1,0 +1,23 @@
+<?php
+require_once '../conexion/db.php';
+
+if(isset($_POST['leer_resultados'])){
+    $db = new DB();
+    $c = $db->conectar();
+    $stmt = $c->prepare("SELECT e.descripcion AS especialidad, c.descripcion AS curso, SUM(id.logrado) AS total_logrado
+                         FROM indicador_detalle id
+                         INNER JOIN indicador_cabecera ic ON ic.id_indicador_cabecera=id.id_indicador_cabecera
+                         INNER JOIN proyecto_curso pc ON pc.id_proyecto_curso=ic.id_proyecto_curso
+                         INNER JOIN cursos c ON c.id_curso=pc.id_curso
+                         INNER JOIN curso_especialidades ce ON ce.id_curso=c.id_curso
+                         INNER JOIN especialidades e ON e.id_especialidad=ce.id_especialidad
+                         GROUP BY e.descripcion, c.descripcion
+                         ORDER BY total_logrado DESC");
+    $stmt->execute();
+    if($stmt->rowCount()){
+        print_r(json_encode($stmt->fetchAll(PDO::FETCH_ASSOC)));
+    }else{
+        echo '0';
+    }
+    exit;
+}

--- a/menu.php
+++ b/menu.php
@@ -340,6 +340,13 @@
                             </a>
                         </li>
 
+                        <li class="nav-item">
+                            <a class="nav-link" onclick="mostrarResultados(); return false;" href="#">
+                                <i class="typcn typcn-chart-bar-outline menu-icon"></i>
+                                <span class="menu-title">Resultados</span>
+                            </a>
+                        </li>
+
 
                         <li class="nav-item">
                             <a class="nav-link" href="controlador/cerrarSesion.php" aria-expanded="false" >
@@ -407,6 +414,8 @@
         <script src="vista/indicador.js"></script>
 
         <script src="vista/jurado.js"></script>
+
+        <script src="vista/resultados.js"></script>
 
 
 

--- a/paginas/movimientos/resultados/listar.php
+++ b/paginas/movimientos/resultados/listar.php
@@ -1,0 +1,22 @@
+<div class="container-fluid card" style="padding: 30px;">
+    <div class="row">
+        <div class="col-md-12">
+            <h3>Resultados por Especialidad y Curso</h3>
+        </div>
+        <div class="col-md-12" style="margin-top: 30px;">
+            <div class="table-responsive">
+                <table class="table table-bordered table-striped table-head-bg-primary mt-4">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Especialidad</th>
+                            <th>Curso</th>
+                            <th>Puntaje Total</th>
+                        </tr>
+                    </thead>
+                    <tbody id="resultados_tb"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/vista/resultados.js
+++ b/vista/resultados.js
@@ -1,0 +1,34 @@
+function mostrarResultados(){
+    let contenido = dameContenido("paginas/movimientos/resultados/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaResultados();
+}
+
+async function cargarTablaResultados(){
+    const body = new URLSearchParams();
+    body.append('leer_resultados', '1');
+    const response = await fetch('controlador/resultados.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'},
+        body
+    });
+    let datos = await response.text();
+    try{
+        datos = JSON.parse(datos);
+    }catch(e){
+        datos = [];
+    }
+    let fila = '';
+    if(Array.isArray(datos)){
+        let i = 1;
+        datos.forEach(d => {
+            fila += `<tr>
+                        <td>${i++}</td>
+                        <td>${d.especialidad}</td>
+                        <td>${d.curso}</td>
+                        <td>${d.total_logrado}</td>
+                      </tr>`;
+        });
+    }
+    $("#resultados_tb").html(fila);
+}


### PR DESCRIPTION
## Summary
- provide results endpoint to aggregate `indicador_detalle` scores
- list results grouped by especialidad and curso
- add JS utilities to load results view
- link new Results option in menu

## Testing
- `php -l controlador/resultados.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a66f1ad08333941c3eea10aa843e