### PR TITLE
Add project grouping in results

### DIFF
--- a/controlador/resultados.php
+++ b/controlador/resultados.php
@@ -4,6 +4,8 @@ require_once '../conexion/db.php';
 if(isset($_POST['leer_resultados'])){
     $db = new DB();
     $c = $db->conectar();
+
+    // Resultados agrupados por especialidad y curso
     $stmt = $c->prepare("SELECT e.descripcion AS especialidad, c.descripcion AS curso, SUM(id.logrado) AS total_logrado
                          FROM indicador_detalle id
                          INNER JOIN indicador_cabecera ic ON ic.id_indicador_cabecera=id.id_indicador_cabecera
@@ -13,12 +15,42 @@ if(isset($_POST['leer_resultados'])){
                          INNER JOIN especialidades e ON e.id_especialidad=ce.id_especialidad
                          GROUP BY e.descripcion, c.descripcion
                          ORDER BY e.descripcion, total_logrado DESC");
-
     $stmt->execute();
-    if($stmt->rowCount()){
-        print_r(json_encode($stmt->fetchAll(PDO::FETCH_ASSOC)));
-    }else{
-        echo '0';
+    $curso = $stmt->rowCount() ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
+
+    // Resultados agrupados por proyecto
+    $stmt = $c->prepare("SELECT e.descripcion AS especialidad, c.descripcion AS curso, p.descripcion AS proyecto, SUM(id.logrado) AS total_logrado
+                         FROM indicador_detalle id
+                         INNER JOIN indicador_cabecera ic ON ic.id_indicador_cabecera=id.id_indicador_cabecera
+                         INNER JOIN proyecto_curso pc ON pc.id_proyecto_curso=ic.id_proyecto_curso
+                         INNER JOIN cursos c ON c.id_curso=pc.id_curso
+                         INNER JOIN proyectos p ON p.id_proyecto=pc.id_proyecto
+                         INNER JOIN curso_especialidades ce ON ce.id_curso=c.id_curso
+                         INNER JOIN especialidades e ON e.id_especialidad=ce.id_especialidad
+                         GROUP BY e.descripcion, c.descripcion, p.descripcion
+                         ORDER BY e.descripcion, c.descripcion, total_logrado DESC");
+    $stmt->execute();
+    $proyecto = $stmt->rowCount() ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
+
+    // Premios: mejor proyecto por curso y por especialidad
+    $mejorCurso = [];
+    $mejorEspecialidad = [];
+    foreach($proyecto as $p){
+        if(!isset($mejorCurso[$p['curso']]) || $mejorCurso[$p['curso']]['total_logrado'] < $p['total_logrado']){
+            $mejorCurso[$p['curso']] = ['proyecto' => $p['proyecto'], 'total_logrado' => $p['total_logrado']];
+        }
+        if(!isset($mejorEspecialidad[$p['especialidad']]) || $mejorEspecialidad[$p['especialidad']]['total_logrado'] < $p['total_logrado']){
+            $mejorEspecialidad[$p['especialidad']] = ['proyecto' => $p['proyecto'], 'total_logrado' => $p['total_logrado']];
+        }
     }
+
+    $respuesta = [
+        'por_curso' => $curso,
+        'por_proyecto' => $proyecto,
+        'mejor_curso' => $mejorCurso,
+        'mejor_especialidad' => $mejorEspecialidad
+    ];
+
+    print_r(json_encode($respuesta));
     exit;
 }

--- a/paginas/movimientos/resultados/listar.php
+++ b/paginas/movimientos/resultados/listar.php
@@ -23,7 +23,19 @@
                     <tbody id="resultados_tb"></tbody>
                 </table>
             </div>
-
         </div>
+
+        <div class="col-md-12" style="margin-top: 40px;">
+            <h3>Resultados por Proyecto</h3>
+            <div id="resultados_proyecto_cnt"></div>
+        </div>
+
+        <div class="col-md-12" style="margin-top: 40px;">
+            <h3>Premio al Mejor Proyecto del Curso</h3>
+            <div id="premio_curso_cnt"></div>
+            <h3 class="mt-4">Premio al Mejor Proyecto de la Especialidad</h3>
+            <div id="premio_especialidad_cnt"></div>
+        </div>
+
     </div>
 </div>

--- a/vista/resultados.js
+++ b/vista/resultados.js
@@ -16,14 +16,14 @@ async function cargarTablaResultados(){
     try{
         datos = JSON.parse(datos);
     }catch(e){
-        datos = [];
+        datos = null;
     }
 
-    if(Array.isArray(datos)){
+    if(datos && Array.isArray(datos.por_curso)){
         const cont = $("#resultados_cnt");
         cont.html('');
         const grupos = {};
-        datos.forEach(d => {
+        datos.por_curso.forEach(d => {
             if(!grupos[d.especialidad]){
                 grupos[d.especialidad] = [];
             }
@@ -45,9 +45,9 @@ async function cargarTablaResultados(){
     }
 
     let fila = '';
-    if(Array.isArray(datos)){
+    if(datos && Array.isArray(datos.por_curso)){
         let i = 1;
-        datos.forEach(d => {
+        datos.por_curso.forEach(d => {
             fila += `<tr>
                         <td>${i++}</td>
                         <td>${d.especialidad}</td>
@@ -57,5 +57,54 @@ async function cargarTablaResultados(){
         });
     }
     $("#resultados_tb").html(fila);
+
+    // Resultados por proyecto
+    if(datos && Array.isArray(datos.por_proyecto)){
+        const cont = $("#resultados_proyecto_cnt");
+        cont.html('');
+        const grupos = {};
+        datos.por_proyecto.forEach(d => {
+            if(!grupos[d.curso]){
+                grupos[d.curso] = [];
+            }
+            grupos[d.curso].push(d);
+        });
+        Object.keys(grupos).forEach(cur => {
+            let html = `<h4>${cur}</h4>`;
+            html += '<div class="table-responsive">';
+            html += '<table class="table table-bordered table-striped table-head-bg-primary mt-2">';
+            html += '<thead><tr><th>#</th><th>Proyecto</th><th>Puntaje Total</th></tr></thead><tbody>';
+            grupos[cur].forEach((r, idx) => {
+                html += `<tr><td>${idx + 1}</td><td>${r.proyecto}</td><td>${r.total_logrado}</td></tr>`;
+            });
+            html += '</tbody></table></div>';
+            cont.append(html);
+        });
+    } else {
+        $("#resultados_proyecto_cnt").html('');
+    }
+
+    // Premios
+    if(datos && datos.mejor_curso){
+        const cont = $("#premio_curso_cnt");
+        cont.html('');
+        Object.keys(datos.mejor_curso).forEach(cur => {
+            const r = datos.mejor_curso[cur];
+            cont.append(`<p><strong>${cur}:</strong> ${r.proyecto} (${r.total_logrado} puntos)</p>`);
+        });
+    } else {
+        $("#premio_curso_cnt").html('');
+    }
+
+    if(datos && datos.mejor_especialidad){
+        const cont = $("#premio_especialidad_cnt");
+        cont.html('');
+        Object.keys(datos.mejor_especialidad).forEach(esp => {
+            const r = datos.mejor_especialidad[esp];
+            cont.append(`<p><strong>${esp}:</strong> ${r.proyecto} (${r.total_logrado} puntos)</p>`);
+        });
+    } else {
+        $("#premio_especialidad_cnt").html('');
+    }
 
 }


### PR DESCRIPTION
## Summary
- enhance results endpoint to include project-level grouping
- compute awards for best project per course and per specialty
- display new sections for project results and awards in the frontend

## Testing
- `node -c vista/resultados.js`

------
https://chatgpt.com/codex/tasks/task_e_6864a9555ecc8333b354fbfa892ac0de